### PR TITLE
[iOS] Added "all", "images" query utils that can be used in the console

### DIFF
--- a/lib/testmunk/calabash/ios/utils/query.rb
+++ b/lib/testmunk/calabash/ios/utils/query.rb
@@ -1,0 +1,28 @@
+require 'calabash-cucumber/operations'
+
+
+module Testmunk
+  module IOS
+    module Utils
+      module Query
+        include Calabash::Cucumber::Operations
+
+        def images(param)
+          query('UIImageView').each do |image|
+            p = image[param.to_s]
+            puts p unless p.nil? || p.empty?
+          end
+          nil
+        end
+
+        def all(param)
+          query('*').each do |image|
+            p = image[param.to_s]
+            puts p unless p.nil? || p.empty?
+          end
+          nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
@ysilyutin @KaterynaTs @HannaPiatrouskaya @mposchen 
It's difficult to list all labels or ids of iOS views. You can use these methods to have them in a clean form.

Here is what I'm adding in my calabash console. Ping me if you need more help
![image](https://cloud.githubusercontent.com/assets/7532782/8983509/1f68b9e4-36cb-11e5-9d6b-62b3691ce105.png)

```
all :label
images :id
```

any parameter from `query` works here

![image](https://cloud.githubusercontent.com/assets/7532782/8983481/e4750b9e-36ca-11e5-9465-5e84846ec13e.png)
